### PR TITLE
added publishConfig to package.json

### DIFF
--- a/packages/graphiql-plugin-multipart-requests/package.json
+++ b/packages/graphiql-plugin-multipart-requests/package.json
@@ -3,7 +3,7 @@
   "collaborators": [
     "Dylan Owen <dylan.owen@workday.com>"
   ],
-  "version": "0.0.1",
+  "version": "0.0.2",
   "scripts": {
     "dev": "tsc --project ./tsconfig.dev.json --watch --pretty --incremental --preserveWatchOutput",
     "test:unit": "jest",

--- a/packages/graphiql-plugin-multipart-requests/package.json
+++ b/packages/graphiql-plugin-multipart-requests/package.json
@@ -11,6 +11,10 @@
     "release": "tshy",
     "clean": "rimraf dist/"
   },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
   "type": "module",
   "exports": {
     "./package.json": "./package.json",


### PR DESCRIPTION
Added publish config to publish to the correct registry. This gets around the default wanting to publish to Artifactory instead of npm. 