### PR TITLE
add --yes flag to publish command

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "demo:record": "RECORD_DEMO=true npx playwright test --config ./tests --project=chromium ./integration/demo.spec.ts",
     "demo:convert": "find . -type f -name \"demo.webm\" -exec bash -c 'ffmpeg -y -i \"$0\" -ss 1 -vf \"scale=1000:-1:flags=lanczos,split[s0][s1];[s0]palettegen[p];[s1][p]paletteuse=dither=bayer:bayer_scale=4\" -c:v gif \"${0%.webm}.gif\" && rm \"$0\"' {} \\;",
     "precommit": "npm run lint && npm run test && npm run release",
-    "publish:npm": "lerna publish from-package",
+    "publish:npm": "lerna publish from-package --yes",
     "build": "lerna run build",
     "release": "lerna run release",
     "clean": "lerna run clean --stream"


### PR DESCRIPTION
## 📌 Description

Added --yes flag to get past publish prompts when pipeline publishes. 

This should help github action not timeout when trying to release. By auto saying yes to all the do you want to publish prompts. 

Also, not in this PR but I updated the github token to use the correct account that has npm publish permissions. 

---

## 🔍 Changes Made

- [x] Brief bullet-point list of changes
- [x] Highlight **key files or logic updated**
- [x] Mention **any breaking changes** or impacts

---

## 🧪 Testing

- [x] Tested locally
- [x] Unit tests updated/added
- [x] CI pipeline passed (lint, tests)

Describe **how you tested the changes** and any edge cases considered.

Ran the command locally, and it passes
---

## 📷 Screenshots (if UI-related)

> Add screenshots or GIFs showing before/after, if applicable.

---

## ✅ Checklist

Please confirm all items are complete before requesting a review:

- [x] I have run `lint` and fixed any issues
- [x] I have run all existing tests and they pass
- [x] I have added tests for new code (if needed)
- [x] I have documented my changes (if needed)
- [x] Linked relevant issues in the PR description

---

## 📣 Reviewer Notes

> Is there anything you’d like reviewers to focus on, or any context that’s useful for them?

---
