### PR TITLE
APITOOLS-4071 a11y delete edit buttons

### DIFF
--- a/packages/graphiql-plugin-multipart-requests/src/plugin.tsx
+++ b/packages/graphiql-plugin-multipart-requests/src/plugin.tsx
@@ -72,7 +72,7 @@ export function AttachmentContent({ name, value, updateAttachment, error }: Atta
     <div className={'attachment-content'}>
       <div className={'attachment-title'}>
         <PartNameComponent name={name} setName={(name) => updateAttachment({ action: 'update', name })} />
-        <button onClick={() => updateAttachment({ action: 'delete' })} className={'attachment-delete'}>
+        <button aria-label={`Delete attachment ${name}`} onClick={() => updateAttachment({ action: 'delete' })} className={'attachment-delete'}>
           <TrashIcon />
         </button>
       </div>
@@ -114,39 +114,35 @@ export function PartNameComponent({ name, setName }: { name: string; setName: (n
       setName(inputRef.current.value);
     }
   }
-  function onSubmit(event: React.BaseSyntheticEvent) {
-    event.preventDefault();
-    event.stopPropagation();
-    endEditing();
-  }
-
+  
   if (isEditing) {
     return (
-      <form onSubmit={onSubmit}>
         <input
           ref={inputRef}
           type='text'
+          aria-label='Part name'
           defaultValue={name}
           onBlur={endEditing}
           onKeyDown={(e) => {
-            if (e.key === 'Escape') {
-              onSubmit(e);
+            if (e.key === 'Escape' || e.key === 'Enter') {
+              endEditing();
             }
-          }}
-        />
-      </form>
-    );
-  } else {
-    return (
-      <>
-        <span onClick={() => setIsEditing(true)} style={{ cursor: 'pointer' }}>
-          {name}
-          &nbsp;
-          <PenIcon />
-        </span>
-      </>
+          }} />
     );
   }
+
+  return (
+    <>
+      <span>{name}</span>
+      <button 
+        onClick={() => setIsEditing(true)} 
+        aria-label={`Edit part name: ${name}`}
+        title="Edit part name"
+      >
+        <PenIcon />
+      </button>
+    </>
+  );
 }
 
 export function PartHeadersComponent({ name, value }: { name: string; value: File }) {

--- a/packages/graphiql-plugin-multipart-requests/src/plugin.tsx
+++ b/packages/graphiql-plugin-multipart-requests/src/plugin.tsx
@@ -117,7 +117,10 @@ export function PartNameComponent({ name, setName }: { name: string; setName: (n
   
   if (isEditing) {
     return (
+      <label className='attachment-part-name-edit-label'>
+        Part name:
         <input
+          className='attachment-part-name-edit-input'
           ref={inputRef}
           type='text'
           aria-label='Part name'
@@ -127,13 +130,15 @@ export function PartNameComponent({ name, setName }: { name: string; setName: (n
             if (e.key === 'Escape' || e.key === 'Enter') {
               endEditing();
             }
-          }} />
+          }}
+        />
+      </label>
     );
   }
 
   return (
-    <>
-      <span>{name}</span>
+    <span className='attachment-part-name-view'>
+      <span>Part name: {name}</span>
       <button 
         onClick={() => setIsEditing(true)} 
         aria-label={`Edit part name: ${name}`}
@@ -141,7 +146,7 @@ export function PartNameComponent({ name, setName }: { name: string; setName: (n
       >
         <PenIcon />
       </button>
-    </>
+    </span>
   );
 }
 

--- a/packages/graphiql-plugin-multipart-requests/style.css
+++ b/packages/graphiql-plugin-multipart-requests/style.css
@@ -35,6 +35,8 @@
 .attachment-title {
     display: flex;
     justify-content: space-between;
+    align-items: center;
+    min-height: 2.2em;
     font-size: var(--font-size-h3);
     font-family: var(--font-family-mono);
 }

--- a/packages/graphiql-plugin-multipart-requests/style.css
+++ b/packages/graphiql-plugin-multipart-requests/style.css
@@ -59,6 +59,7 @@
 .attachment-part-name-edit-input {
     width: 10em;
     max-width: 100%;
+    margin-left: var(--px-10);
 }
 
 button.attachment-delete {

--- a/packages/graphiql-plugin-multipart-requests/style.css
+++ b/packages/graphiql-plugin-multipart-requests/style.css
@@ -49,6 +49,18 @@
     flex: 0 1 auto;
 }
 
+.attachment-part-name-edit-label,
+.attachment-part-name-view {
+  display: inline-flex;
+  align-items: center;
+  white-space: nowrap;
+}
+
+.attachment-part-name-edit-input {
+    width: 10em;
+    max-width: 100%;
+}
+
 button.attachment-delete {
     width: 2em;
     font-size: 0.8em;

--- a/packages/graphiql-plugin-multipart-requests/tests/__snapshots__/plugin.test.tsx.snap
+++ b/packages/graphiql-plugin-multipart-requests/tests/__snapshots__/plugin.test.tsx.snap
@@ -8,17 +8,22 @@ exports[`AttachmentContent renders a valid attachment 1`] = `
     <div
       class="attachment-title"
     >
-      <span>
-        a
-      </span>
-      <button
-        aria-label="Edit part name: a"
-        title="Edit part name"
+      <span
+        class="attachment-part-name-view"
       >
-        <div>
-          PenIcon
-        </div>
-      </button>
+        <span>
+          Part name: 
+          a
+        </span>
+        <button
+          aria-label="Edit part name: a"
+          title="Edit part name"
+        >
+          <div>
+            PenIcon
+          </div>
+        </button>
+      </span>
       <button
         aria-label="Delete attachment a"
         class="attachment-delete"
@@ -73,17 +78,22 @@ exports[`AttachmentContent renders an invalid attachment 1`] = `
     <div
       class="attachment-title"
     >
-      <span>
-        a
-      </span>
-      <button
-        aria-label="Edit part name: a"
-        title="Edit part name"
+      <span
+        class="attachment-part-name-view"
       >
-        <div>
-          PenIcon
-        </div>
-      </button>
+        <span>
+          Part name: 
+          a
+        </span>
+        <button
+          aria-label="Edit part name: a"
+          title="Edit part name"
+        >
+          <div>
+            PenIcon
+          </div>
+        </button>
+      </span>
       <button
         aria-label="Delete attachment a"
         class="attachment-delete"
@@ -191,16 +201,21 @@ exports[`PartHeadersComponent renders a file 1`] = `
 
 exports[`PartNameComponent renders a part 1`] = `
 <div>
-  <span>
-    a
-  </span>
-  <button
-    aria-label="Edit part name: a"
-    title="Edit part name"
+  <span
+    class="attachment-part-name-view"
   >
-    <div>
-      PenIcon
-    </div>
-  </button>
+    <span>
+      Part name: 
+      a
+    </span>
+    <button
+      aria-label="Edit part name: a"
+      title="Edit part name"
+    >
+      <div>
+        PenIcon
+      </div>
+    </button>
+  </span>
 </div>
 `;

--- a/packages/graphiql-plugin-multipart-requests/tests/__snapshots__/plugin.test.tsx.snap
+++ b/packages/graphiql-plugin-multipart-requests/tests/__snapshots__/plugin.test.tsx.snap
@@ -8,16 +8,19 @@ exports[`AttachmentContent renders a valid attachment 1`] = `
     <div
       class="attachment-title"
     >
-      <span
-        style="cursor: pointer;"
-      >
+      <span>
         a
-         
+      </span>
+      <button
+        aria-label="Edit part name: a"
+        title="Edit part name"
+      >
         <div>
           PenIcon
         </div>
-      </span>
+      </button>
       <button
+        aria-label="Delete attachment a"
         class="attachment-delete"
       >
         <div>
@@ -70,16 +73,19 @@ exports[`AttachmentContent renders an invalid attachment 1`] = `
     <div
       class="attachment-title"
     >
-      <span
-        style="cursor: pointer;"
-      >
+      <span>
         a
-         
+      </span>
+      <button
+        aria-label="Edit part name: a"
+        title="Edit part name"
+      >
         <div>
           PenIcon
         </div>
-      </span>
+      </button>
       <button
+        aria-label="Delete attachment a"
         class="attachment-delete"
       >
         <div>
@@ -185,14 +191,16 @@ exports[`PartHeadersComponent renders a file 1`] = `
 
 exports[`PartNameComponent renders a part 1`] = `
 <div>
-  <span
-    style="cursor: pointer;"
-  >
+  <span>
     a
-     
+  </span>
+  <button
+    aria-label="Edit part name: a"
+    title="Edit part name"
+  >
     <div>
       PenIcon
     </div>
-  </span>
+  </button>
 </div>
 `;

--- a/packages/graphiql-plugin-multipart-requests/tests/plugin.test.tsx
+++ b/packages/graphiql-plugin-multipart-requests/tests/plugin.test.tsx
@@ -24,6 +24,11 @@ describe('AttachmentContent', () => {
         .container
     ).toMatchSnapshot();
   });
+  test('delete button has an accessible name', () => {
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    const { getByRole } = render(<AttachmentContent name='a' value={new File([], 'A')} updateAttachment={() => {}} />);
+    expect(getByRole('button', { name: 'Delete attachment a' })).toBeTruthy();
+  });
 });
 
 describe('PartNameComponent', () => {
@@ -39,7 +44,7 @@ describe('PartNameComponent', () => {
       return render(<PartNameComponent name='a' setName={setName} />, { container });
     });
     act(() => {
-      container.querySelector('span')!.click();
+      container.querySelector('button')!.click();
     });
     act(() => {
       const input = container.querySelector('input')!;
@@ -47,6 +52,11 @@ describe('PartNameComponent', () => {
       input.blur();
     });
     expect(setName).toHaveBeenCalledWith('newName');
+  });
+  test('edit part name is a button with accessible name', () => {
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    const { getByRole } = render(<PartNameComponent name='a' setName={() => {}} />);
+    expect(getByRole('button', { name: 'Edit part name: a' })).toBeTruthy();
   });
 });
 describe('PartHeadersComponent', () => {


### PR DESCRIPTION
## 📌 Description

Please include a summary of the changes and the related issue. Be concise but clear.
---

- Added accessible name for the delete button.
- Updated part-name editing to use a keyboard-accessible edit button with an accessible name.
- Added Part name labeling for the editable input.

## 🔍 Changes Made

- [x] Brief bullet-point list of changes
- [ ] Highlight **key files or logic updated**
- [ ] Mention **any breaking changes** or impacts

---

## 🧪 Testing

- [x] Tested locally
- [x] Unit tests updated/added
- [x] CI pipeline passed (lint, tests)

Describe **how you tested the changes** and any edge cases considered.

---

## 📷 Screenshots (if UI-related)

> Add screenshots or GIFs showing before/after, if applicable.
---

<img width="502" height="865" alt="Screenshot 2026-05-18 at 8 48 33 AM" src="https://github.com/user-attachments/assets/2c6b52d7-0069-4b6f-9fd3-c79b5d6c67d6" />

## ✅ Checklist

Please confirm all items are complete before requesting a review:

- [x] I have run `lint` and fixed any issues
- [x] I have run all existing tests and they pass
- [x] I have added tests for new code (if needed)
- [x] I have documented my changes (if needed)
- [x] Linked relevant issues in the PR description

---

## 📣 Reviewer Notes

> Is there anything you’d like reviewers to focus on, or any context that’s useful for them?

---

Thank you for your contribution! 🙌